### PR TITLE
Fix drag target selection for windows

### DIFF
--- a/features/homepage98/draggable.js
+++ b/features/homepage98/draggable.js
@@ -1,6 +1,7 @@
 function makeDraggableWithClick(dragHandle, onClick) {
   let startX, startY, dragging = false;
-  const container = dragHandle.parentElement.parentElement; // move the whole window
+  // Determine the element that should move when dragging
+  const container = dragHandle.parentElement;
 
   dragHandle.addEventListener('mousedown', function (e) {
     e.preventDefault(); // prevent text selection


### PR DESCRIPTION
## Summary
- adjust draggable container logic so dragging headers moves only their parent window

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684376a56e808333b30fe976d1f9cf47