### PR TITLE
Fix window click obstruction

### DIFF
--- a/features/homepage98/index.html
+++ b/features/homepage98/index.html
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div id="windows" style="position: absolute; inset: 0; z-index: 20;"></div>
-    <div id="icons" style="position: absolute; inset: 0; z-index: 30; padding: 16px;"></div>
+    <div id="icons" style="position: absolute; inset: 0; z-index: 30; padding: 16px; pointer-events: none;"></div>
   </div>
 
   <script>

--- a/features/homepage98/logicmanager.js
+++ b/features/homepage98/logicmanager.js
@@ -61,6 +61,7 @@ function logicManager() {
       icon.className = 'absolute cursor-pointer text-center text-white hover:bg-slate-700 rounded-lg p-2 w-16';
       icon.style.left = `${40 + index * 100}px`;
       icon.style.top = `40px`;
+      icon.style.pointerEvents = 'auto';
       icon.innerHTML = `<div class='text-3xl'>${app.icon}</div><div class='text-xs'>${app.title}</div>`;
       iconsEl.appendChild(icon);
 


### PR DESCRIPTION
## Summary
- prevent the `#icons` container from intercepting clicks
- keep app icons clickable when they are rendered

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6843863ed7548333a11e164eeaf0c867